### PR TITLE
Registry pull-through cache

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,6 +25,21 @@ options:
     type: string
     default: ""
     description: The name of the server which authentication tokens will be addressed to.
+  cache-password:
+    type: string
+    default: ""
+    description: Password for the remote registry when configured as a pull-through cache.
+  cache-remoteurl:
+    type: string
+    default: ""
+    description: |
+      Configures the registry as a pull through cache of the registry at the
+      given url. See https://docs.docker.com/registry/recipes/mirror/ for more
+      information the limitations of this mode.
+  cache-username:
+    type: string
+    default: ""
+    description: Username for the remote registry when configured as a pull-through cache.
   http-host:
     type: string
     default: ""

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -89,6 +89,15 @@ def configure_registry():
         }
     }
 
+    # proxy (https://docs.docker.com/registry/configuration/#proxy)
+    # Sets up registry as a pull-throuch cache
+    if charm_config.get('cache-remoteurl'):
+        registry_config['proxy'] = {
+            'remoteurl' : charm_config.get('cache-remoteurl', ''),
+            'username' : charm_config.get('cache-username', ''),
+            'password' : charm_config.get('cache-password', ''),
+        }
+
     # storage (https://docs.docker.com/registry/configuration/#storage)
     # we must have 1 (and only 1) storage driver
     storage = {}


### PR DESCRIPTION
This exposes docker registry "proxy" settings which configures it as a pull-through cache.

See https://docs.docker.com/registry/recipes/mirror/