### PR TITLE
clear client-configured flag when the docker-registry relation leaves

### DIFF
--- a/reactive/docker_registry.py
+++ b/reactive/docker_registry.py
@@ -94,6 +94,11 @@ def config_changed():
     report_status()
 
 
+@when_not("endpoint.docker-registry.joined")
+def remove_client():
+    clear_flag('charm.docker-registry.client-configured')
+
+
 @when('charm.docker-registry.configured',
       'endpoint.docker-registry.joined')
 @when_not('charm.docker-registry.client-configured')


### PR DESCRIPTION
when the docker-registry relation is broken between docker-registry and containerd, this charm leaves `charm.docker-registry.client-configured` set.  When a new relation joins, this prevents the `configure_client` code from setting all the registry config again on the relation
