### PR TITLE
Fix implementation of registry-port

### DIFF
--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -42,8 +42,9 @@ def configure_registry():
     registry_config['auth'] = auth
 
     # http (https://docs.docker.com/registry/configuration/#http)
-    port = charm_config.get('registry-port')
-    http = {'addr': '0.0.0.0:{}'.format(port),
+    # Registry can always listen on port 5000, with registry-port used
+    # for mapping from the host networking only.
+    http = {'addr': '0.0.0.0:5000',
             'headers': {'X-Content-Type-Options': ['nosniff']},
             'relativeurls': True}
     if charm_config.get('http-host'):


### PR DESCRIPTION
Part of the charm code was assuming that the registry would always
run on port 5000 within the docker container, however the registry
configuration file was being rendered with the registry-port
so the host to container port mapping was broken.

Just always listen on 5000 and use the port mapping to implement
the registry-port option.