### PR TITLE
pin python-libjuju to pre 3.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,5 @@ deps =
     pytest
     pytest-operator
     ipdb
+    juju < 3.0  # https://github.com/juju/python-libjuju/issues/719
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration


### PR DESCRIPTION
pin python-libjuju as its breaking integration tests