### PR TITLE
new storage cache config option

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,8 @@ jobs:
   lint-unit:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    with:
+      python: "['3.8', '3.9', '3.10', '3.11']"
     needs:
       - call-inclusive-naming-check 
 
@@ -22,14 +24,15 @@ jobs:
       - lint-unit
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          juju-channel: 3/stable
       - name: Run integration test
         run: tox -e integration

--- a/config.yaml
+++ b/config.yaml
@@ -88,8 +88,8 @@ options:
     type: string
     default: "inmemory"
     description: |
-      Cache provider for image layer metadata. Valid options are "inmemory" or "redis".
-      Any other value disables the cache.
+      Cache provider for image layer metadata. Valid options are "inmemory" or
+      "disabled".
   storage-delete:
     type: boolean
     default: false

--- a/config.yaml
+++ b/config.yaml
@@ -84,6 +84,12 @@ options:
     default:
     description: |
       The HTTPS proxy the registry server should use to access the upstream registry.
+  storage-cache:
+    type: string
+    default: "inmemory"
+    description: |
+      Cache provider for image layer metadata. Valid options are "inmemory" or "redis".
+      Any other value disables the cache.
   storage-delete:
     type: boolean
     default: false

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -15,6 +15,22 @@ from charms.reactive import endpoint_from_flag, is_flag_set
 from charms.reactive.helpers import any_file_changed, data_changed
 
 
+def has_invalid_config():
+    """Checks charm config for invalid values.
+
+    If invalid values are found, return a list of the offending key(s). Otherwise,
+    return an empty list.
+    """
+    charm_config = hookenv.config()
+    bad_config = []
+
+    storage_cache = charm_config.get("storage-cache", "")
+    if storage_cache not in ["inmemory", "disabled"]:
+        bad_config.append("storage-cache")
+
+    return bad_config
+
+
 def configure_registry():
     '''Recreate the docker registry config.yml.'''
     charm_config = hookenv.config()

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -158,8 +158,8 @@ def configure_registry():
         storage['delete'] = {'enabled': True}
     if charm_config.get('storage-read-only'):
         storage['maintenance'] = {'readonly': {'enabled': True}}
-    storage_cache = charm_config.get('storage-cache', 'inmemory')
-    storage['cache'] = {'blobdescriptor': storage_cache}
+    if charm_config.get('storage-cache', 'inmemory') == 'inmemory':
+        storage['cache'] = {'blobdescriptor': 'inmemory'}
     registry_config['storage'] = storage
 
     os.makedirs(os.path.dirname(registry_config_file), exist_ok=True)

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -108,7 +108,7 @@ def configure_registry():
             'password': charm_config.get('cache-password', ''),
         }
 
-    # storage (https://docs.docker.com/registry/configuration/#storage)
+    # storage (https://distribution.github.io/distribution/about/configuration/#storage)
     # we must have 1 (and only 1) storage driver
     storage = {}
     if charm_config.get('storage-swift-authurl'):
@@ -132,7 +132,6 @@ def configure_registry():
         # If we're not swift, we're local.
         container_registry_path = '/var/lib/registry'
         storage['filesystem'] = {'rootdirectory': container_registry_path}
-        storage['cache'] = {'blobdescriptor': 'inmemory'}
 
         # Local storage is mounted from the host so images persist across
         # registry container restarts.
@@ -143,6 +142,8 @@ def configure_registry():
         storage['delete'] = {'enabled': True}
     if charm_config.get('storage-read-only'):
         storage['maintenance'] = {'readonly': {'enabled': True}}
+    storage_cache = charm_config.get('storage-cache', 'inmemory')
+    storage['cache'] = {'blobdescriptor': storage_cache}
     registry_config['storage'] = storage
 
     os.makedirs(os.path.dirname(registry_config_file), exist_ok=True)

--- a/tests/integration/test_docker_registry_integration.py
+++ b/tests/integration/test_docker_registry_integration.py
@@ -46,9 +46,8 @@ async def test_push_image(ops_test):
     for unit in registry_units:
         action = await unit.run_action("push", image="python:3.9-slim", pull=True)
         output = await action.wait()  # wait for result
-        assert output.data.get("status") == "completed"
-        assert output.data.get("results", {}).get("outcome") == "success"
-        assert output.data.get("results", {}).get("raw") == \
+        assert output.status == "completed"
+        assert output.results.get("raw") == \
             f"pushed {unit.public_address}:5000/python:3.9-slim"
 
 
@@ -63,6 +62,5 @@ async def test_image_list(ops_test):
     for unit in registry_units:
         action = await unit.run_action("images", repository="python:3.9-slim")
         output = await action.wait()  # wait for result
-        assert output.data.get("status") == "completed"
-        assert "python" in output.data.get("results", {}).get("output")
-        assert "3.9-slim" in output.data.get("results", {}).get("output")
+        assert output.status == "completed"
+        assert "python" in output.results.get("output")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,4 @@
 import charms.unit_test
 
 charms.unit_test.patch_reactive()
-charms.unit_test.patch_module('charms.leadership')
+charms.unit_test.patch_module("charms.leadership")

--- a/tests/unit/test_docker_registry.py
+++ b/tests/unit/test_docker_registry.py
@@ -38,15 +38,25 @@ def test_series_upgrade(start_registry, stop_registry):
 @mock.patch("charmhelpers.core.hookenv.config")
 @mock.patch("os.makedirs", mock.Mock(return_value=0))
 def test_configure_registry(config, mock_kv, mock_write, mock_host, mock_lc):
+    # storage-cache: invalid value should not result in any cache structure
     config.return_value = {
         "log-level": "bananas",
         "storage-cache": "bananas",
     }
+    with mock.patch("charms.layer.docker_registry.yaml") as mock_yaml:
+        layer.docker_registry.configure_registry()
+        args, _ = mock_yaml.safe_dump.call_args_list[0]
+        assert "cache" not in args[0]["storage"]
+
+    # storage-cache: valid value should result in a populated cache structure
+    config.return_value = {
+        "log-level": "bananas",
+        "storage-cache": "inmemory",
+    }
     expected = {
         "log": {"level": "bananas"},
-        "storage": {"cache": {"blobdescriptor": "bananas"}},
+        "storage": {"cache": {"blobdescriptor": "inmemory"}},
     }
-
     with mock.patch("charms.layer.docker_registry.yaml") as mock_yaml:
         layer.docker_registry.configure_registry()
         args, _ = mock_yaml.safe_dump.call_args_list[0]

--- a/tests/unit/test_docker_registry.py
+++ b/tests/unit/test_docker_registry.py
@@ -51,3 +51,18 @@ def test_configure_registry(config, mock_kv, mock_write, mock_host, mock_lc):
         layer.docker_registry.configure_registry()
         args, _ = mock_yaml.safe_dump.call_args_list[0]
         assert expected["storage"].items() <= args[0]["storage"].items()
+
+
+@mock.patch("charmhelpers.core.hookenv.config")
+def test_has_invalid_config(config):
+    # check valid config is valid
+    config.return_value = {
+        "storage-cache": "disabled",
+    }
+    assert not layer.docker_registry.has_invalid_config()
+
+    # check for bad apples
+    config.return_value = {
+        "storage-cache": "bananas",
+    }
+    assert "storage-cache" in layer.docker_registry.has_invalid_config()

--- a/tests/unit/test_docker_registry.py
+++ b/tests/unit/test_docker_registry.py
@@ -1,4 +1,5 @@
 from charms.unit_test import patch_fixture
+from unittest import mock
 
 from charmhelpers.core import host  # patched
 from charms import layer
@@ -6,8 +7,8 @@ from charms import layer
 from reactive import docker_registry as handlers
 
 
-start_registry = patch_fixture('charms.layer.docker_registry.start_registry')
-stop_registry = patch_fixture('charms.layer.docker_registry.stop_registry')
+start_registry = patch_fixture("charms.layer.docker_registry.start_registry")
+stop_registry = patch_fixture("charms.layer.docker_registry.stop_registry")
 
 
 def test_series_upgrade(start_registry, stop_registry):
@@ -28,3 +29,25 @@ def test_series_upgrade(start_registry, stop_registry):
     assert host.service_pause.call_count == 1
     assert host.service_resume.call_count == 1
     assert layer.status.blocked.call_count == 1
+
+
+@mock.patch("charms.layer.docker_registry._configure_local_client")
+@mock.patch("charms.layer.docker_registry.host")
+@mock.patch("charms.layer.docker_registry._write_tls_blobs_to_files")
+@mock.patch("charms.layer.docker_registry.unitdata")
+@mock.patch("charmhelpers.core.hookenv.config")
+@mock.patch("os.makedirs", mock.Mock(return_value=0))
+def test_configure_registry(config, mock_kv, mock_write, mock_host, mock_lc):
+    config.return_value = {
+        "log-level": "bananas",
+        "storage-cache": "bananas",
+    }
+    expected = {
+        "log": {"level": "bananas"},
+        "storage": {"cache": {"blobdescriptor": "bananas"}},
+    }
+
+    with mock.patch("charms.layer.docker_registry.yaml") as mock_yaml:
+        layer.docker_registry.configure_registry()
+        args, _ = mock_yaml.safe_dump.call_args_list[0]
+        assert expected["storage"].items() <= args[0]["storage"].items()

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,5 @@ deps =
     pytest
     pytest-operator
     ipdb
-    juju < 3.0  # https://github.com/juju/python-libjuju/issues/719
+    juju
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration


### PR DESCRIPTION
[LP:2049360](https://bugs.launchpad.net/layer-docker-registry/+bug/2049360)

This PR provides a new config option `storage-cache` that can be used to switch between 'redis' and 'inmemory' cache types:

https://distribution.github.io/distribution/about/configuration/#cache

More important for the linked bug, any other value will [disable the cache](https://github.com/distribution/distribution/blob/release/2.8/registry/handlers/app.go#L289-L292) altogether.

I've also added a unit test for this option, though this charm could use a lot more help in the coverage department :/