### PR TITLE
Added explicit configuration option `storage-redirect-disable` 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/Inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 

--- a/config.yaml
+++ b/config.yaml
@@ -96,6 +96,14 @@ options:
     description: |
       Enable/disable the "delete" storage option. False, the default, disables
       this option in the registry config file.
+  storage-redirect-disable:
+    type: boolean
+    default: true
+    description: |
+      For backends that support it(swift, s3), redirecting is disabled by default.
+      All data routed through the Registry, rather than redirecting to the backend.
+      If you want to redirect client requests directly to content storage,
+      set this option to false.
   storage-read-only:
     type: boolean
     default: false

--- a/lib/charms/layer/docker_registry.py
+++ b/lib/charms/layer/docker_registry.py
@@ -142,12 +142,10 @@ def configure_registry():
         val = charm_config.get('storage-swift-domain', '')
         if val != '':
             storage['swift'].update({'domain': val})
-
-        storage['redirect'] = {'disable': True}
     elif (
-            charm_config.get('storage-s3-region') and
-            charm_config.get('storage-s3-bucket')
-        ):
+        charm_config.get('storage-s3-region') and
+        charm_config.get('storage-s3-bucket')
+    ):
         storage['s3'] = {
             'region': charm_config.get('storage-s3-region'),
             'bucket': charm_config.get('storage-s3-bucket'),
@@ -199,6 +197,13 @@ def configure_registry():
         storage['maintenance'] = {'readonly': {'enabled': True}}
     if charm_config.get('storage-cache', 'inmemory') == 'inmemory':
         storage['cache'] = {'blobdescriptor': 'inmemory'}
+
+    storage_redirect_disable = charm_config.get('storage-redirect-disable', True)
+
+    # by default redirect is disabled for S3 and Swift backends mostly because this
+    # charm is used in private clouds with private object storage
+    storage['redirect'] = {'disable': storage_redirect_disable}
+
     registry_config['storage'] = storage
 
     os.makedirs(os.path.dirname(registry_config_file), exist_ok=True)


### PR DESCRIPTION
Added charm configuration option `storage-redirect-disable` which allows to configure distribution behavior for s3/swift object storages. We need to provide such an option because this charm could be deployed with private object storage(e.g. CEPH RADOS object storage) and in this case user can't download any artifacts from the registry.

In previous versions of charm storage redirect was disabled implicitly for swift storage only. Now behavior of charm should be more clear and understandable. The default behavior for swift wasn't changed.

\+ added unit tests and  fixed linter issues

LP bug: https://bugs.launchpad.net/layer-docker-registry/+bug/2080349
