### PR TITLE
Adjust layer-download to a script

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,21 +17,7 @@ parts:
     source: src
     plugin: reactive
     override-build: |
-      set -ex
-      rm -rf $CRAFT_STAGE/tmp
-      mkdir -p $CRAFT_STAGE/tmp/interfaces
-      mkdir -p $CRAFT_STAGE/tmp/layers
-      wget "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${CRAFT_ARCH_BUILD_ON}" -O /usr/bin/yq && chmod +x /usr/bin/yq
-      wget "https://raw.githubusercontent.com/charmed-kubernetes/jenkins/refs/heads/main/jobs/includes/charm-layer-list.inc" -O ${CRAFT_STAGE}/tmp/layers.yaml
-      for layer in $(yq '.[] | keys | .[]' $CRAFT_STAGE/tmp/layers.yaml); do
-        if [[ ! "$layer" =~ ^(interface:|layer:) ]]; then continue; fi
-        echo "Pulling layer: ${layer}"
-        charm pull-source \
-          --layer-index ${LAYER_INDEX} \
-          --branch ${RELEASE_BRANCH} \
-          ${layer} &
-      done
-      wait
+      ./prepare_layers.sh
       craftctl default
       git -C $CRAFT_PROJECT_DIR rev-parse --short HEAD > version
     reactive-charm-build-arguments:
@@ -44,6 +30,7 @@ parts:
     - python3-dev
     build-snaps:
     - charm/3.x/stable
+    - yq
     build-environment:
     - CHARM_LAYERS_DIR: $CRAFT_STAGE/tmp/layers/
     - CHARM_INTERFACES_DIR: $CRAFT_STAGE/tmp/interfaces/

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,10 +17,12 @@ parts:
     source: src
     plugin: reactive
     override-build: |
+      set -ex
       rm -rf $CRAFT_STAGE/tmp
       mkdir -p $CRAFT_STAGE/tmp/interfaces
       mkdir -p $CRAFT_STAGE/tmp/layers
-      curl -o $CRAFT_STAGE/tmp/layers.yaml https://raw.githubusercontent.com/charmed-kubernetes/jenkins/refs/heads/main/jobs/includes/charm-layer-list.inc
+      wget "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${CRAFT_ARCH_BUILD_ON}" -O /usr/bin/yq && chmod +x /usr/bin/yq
+      wget "https://raw.githubusercontent.com/charmed-kubernetes/jenkins/refs/heads/main/jobs/includes/charm-layer-list.inc" -O ${CRAFT_STAGE}/tmp/layers.yaml
       for layer in $(yq '.[] | keys | .[]' $CRAFT_STAGE/tmp/layers.yaml); do
         if [[ ! "$layer" =~ ^(interface:|layer:) ]]; then continue; fi
         echo "Pulling layer: ${layer}"
@@ -38,11 +40,10 @@ parts:
     - --debug
     - --force
     build-packages:
-    - curl
+    - wget
     - python3-dev
     build-snaps:
     - charm/3.x/stable
-    - yq
     build-environment:
     - CHARM_LAYERS_DIR: $CRAFT_STAGE/tmp/layers/
     - CHARM_INTERFACES_DIR: $CRAFT_STAGE/tmp/interfaces/

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,12 +17,12 @@ parts:
     source: src
     plugin: reactive
     override-build: |
-      ./prepare_layers.sh
+      ./download_layers.sh
       craftctl default
       git -C $CRAFT_PROJECT_DIR rev-parse --short HEAD > version
     reactive-charm-build-arguments:
     - --layer-index
-    - 'http://localhost'  # Fake layer index to avoid network calls
+    - 'http://localhost/'  # Fake layer index to force a local build
     - --debug
     - --force
     build-packages:

--- a/src/download_layers.sh
+++ b/src/download_layers.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
-# This script is used to prepare the layers for the charm build process.
-# It will pull the layers from the charm store and place them in the tmp directory.
+# This script is used to download reactive layers for the charm build process.
+# It pulls the layers from the gh and place them in the tmp directory.
 set -eu
 
 # ensure we have environment variables set
 : "${RELEASE_BRANCH:?Environment variable RELEASE_BRANCH is not set.}"
 : "${CHARM_LAYERS_DIR:?Environment variable CHARM_LAYERS_DIR is not set.}"
 : "${CHARM_INTERFACES_DIR:?Environment variable CHARM_INTERFACES_DIR is not set.}"
-: "${CRAFT_ARCH_BUILD_ON:=$(dpkg --print-architecture)}"
-: "${LAYER_INDEX:='https://raw.githubusercontent.com/charmed-kubernetes/layer-index/main/'}"
 
 # Ensure the temporary directory was created successfully
 TMP_DIR=$(mktemp -d)
@@ -26,14 +24,14 @@ for cmd in charm wget yq; do
     fi
 done
 
-mkdir -p $CHARM_INTERFACES_DIR
-mkdir -p $CHARM_LAYERS_DIR
+rm -rf $CHARM_LAYERS_DIR && mkdir -p $CHARM_LAYERS_DIR
+rm -rf $CHARM_INTERFACES_DIR && mkdir -p $CHARM_INTERFACES_DIR
 wget "https://raw.githubusercontent.com/charmed-kubernetes/jenkins/refs/heads/main/jobs/includes/charm-layer-list.inc" -O ${TMP_DIR}/layers.yaml
 for layer in $(cat ${TMP_DIR}/layers.yaml | yq '.[] | keys | .[]' - ); do
     if [[ ! "$layer" =~ ^(interface:|layer:) ]]; then continue; fi
     echo "Pulling layer: ${layer}"
     charm pull-source \
-        --layer-index ${LAYER_INDEX} \
+        --layer-index ${LAYER_INDEX:-'https://raw.githubusercontent.com/charmed-kubernetes/layer-index/main/'} \
         --branch ${RELEASE_BRANCH} \
         ${layer} &
 done

--- a/src/prepare_layers.sh
+++ b/src/prepare_layers.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# This script is used to prepare the layers for the charm build process.
+# It will pull the layers from the charm store and place them in the tmp directory.
+set -eu
+
+# ensure we have environment variables set
+: "${RELEASE_BRANCH:?Environment variable RELEASE_BRANCH is not set.}"
+: "${CHARM_LAYERS_DIR:?Environment variable CHARM_LAYERS_DIR is not set.}"
+: "${CHARM_INTERFACES_DIR:?Environment variable CHARM_INTERFACES_DIR is not set.}"
+: "${CRAFT_ARCH_BUILD_ON:=$(dpkg --print-architecture)}"
+: "${LAYER_INDEX:='https://raw.githubusercontent.com/charmed-kubernetes/layer-index/main/'}"
+
+# Ensure the temporary directory was created successfully
+TMP_DIR=$(mktemp -d)
+if [ ! -d "$TMP_DIR" ]; then
+    echo "Failed to create a temporary directory."
+    exit 1
+fi
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# ensure we have the right prerequisites
+for cmd in charm wget yq; do
+    if ! command -v $cmd &> /dev/null; then
+        echo "$cmd command not found. Please install $cmd."
+        exit 1
+    fi
+done
+
+mkdir -p $CHARM_INTERFACES_DIR
+mkdir -p $CHARM_LAYERS_DIR
+wget "https://raw.githubusercontent.com/charmed-kubernetes/jenkins/refs/heads/main/jobs/includes/charm-layer-list.inc" -O ${TMP_DIR}/layers.yaml
+for layer in $(cat ${TMP_DIR}/layers.yaml | yq '.[] | keys | .[]' - ); do
+    if [[ ! "$layer" =~ ^(interface:|layer:) ]]; then continue; fi
+    echo "Pulling layer: ${layer}"
+    charm pull-source \
+        --layer-index ${LAYER_INDEX} \
+        --branch ${RELEASE_BRANCH} \
+        ${layer} &
+done
+wait


### PR DESCRIPTION
I found that when this charm is built on launchpad with an LP builder -- yq gets a permission denied when trying to read the downloaded layer list


```
:: ++ yq '.[] | keys | .[]' /home/buildd/docker-registry-main/build/stage/tmp/layers.yaml
:: Error: open /home/buildd/docker-registry-main/build/stage/tmp/layers.yaml: permission denied
```

I tracked this down to an app armor issue on launchpad builders with yq trying to read a file from a place the snap cannot access.

Reference:
https://chat.canonical.com/canonical/pl/fe9reme1hiy98mspj5pjhkydxa

### Edit
from ^^ thread, it seems the best answer is to use yq and stdin. 

```sh
cat $file | yq '.' -
```
